### PR TITLE
fix template id and change form to div

### DIFF
--- a/src/FileUploadUI.php
+++ b/src/FileUploadUI.php
@@ -66,10 +66,9 @@ class FileUploadUI extends BaseUpload
         $this->fieldOptions['multiple'] = true;
         $this->fieldOptions['id'] = ArrayHelper::getValue($this->options, 'id');
 
-        $this->options['id'] .= '-form';
-        $this->options['enctype'] = 'multipart/form-data';
-        $this->options['uploadTemplateId'] = $this->uploadTemplateId ? : '#template-upload';
-        $this->options['downloadTemplateId'] = $this->downloadTemplateId ? : '#template-download';
+        $this->options['id'] .= '-fileupload';
+        $this->options['data-upload-template-id'] = $this->uploadTemplateId ? : 'template-upload';
+        $this->options['data-download-template-id'] = $this->downloadTemplateId ? : 'template-download';
     }
 
     /**

--- a/src/views/form.php
+++ b/src/views/form.php
@@ -5,7 +5,7 @@ use yii\helpers\Html;
 $context = $this->context;
 ?>
     <!-- The file upload form used as target for the file upload widget -->
-<?= Html::beginForm($context->url, 'post', $context->options); ?>
+<?= Html::beginTag('div', $context->options); ?>
     <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
     <div class="row fileupload-buttonbar">
         <div class="col-lg-7">
@@ -47,4 +47,4 @@ $context = $this->context;
     </div>
     <!-- The table listing the files available for upload/download -->
     <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-<?= Html::endForm();?>
+<?= Html::endTag('div');?>

--- a/src/views/form.php
+++ b/src/views/form.php
@@ -19,18 +19,18 @@ $context = $this->context;
                     : Html::fileInput($context->name, $context->value, $context->fieldOptions);?>
 
             </span>
-            <button type="submit" class="btn btn-primary start">
+            <a class="btn btn-primary start">
                 <i class="glyphicon glyphicon-upload"></i>
                 <span><?= Yii::t('fileupload', 'Start upload') ?></span>
-            </button>
-            <button type="reset" class="btn btn-warning cancel">
+            </a>
+            <a class="btn btn-warning cancel">
                 <i class="glyphicon glyphicon-ban-circle"></i>
                 <span><?= Yii::t('fileupload', 'Cancel upload') ?></span>
-            </button>
-            <button type="button" class="btn btn-danger delete">
+            </a>
+            <a class="btn btn-danger delete">
                 <i class="glyphicon glyphicon-trash"></i>
                 <span><?= Yii::t('fileupload', 'Delete') ?></span>
-            </button>
+            </a>
             <input type="checkbox" class="toggle">
             <!-- The global file processing state -->
             <span class="fileupload-process"></span>

--- a/tests/data/test-file-upload-ui.bin
+++ b/tests/data/test-file-upload-ui.bin
@@ -83,7 +83,7 @@
 
 </script>
     <!-- The file upload form used as target for the file upload widget -->
-<form id="model-test-form" action="http://example.com/upload.php" method="post" enctype="multipart/form-data" uploadTemplateId="#template-upload" downloadTemplateId="#template-download">    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+<div id="model-test-fileupload" data-upload-template-id="template-upload" data-download-template-id="template-download">    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
     <div class="row fileupload-buttonbar">
         <div class="col-lg-7">
             <!-- The fileinput-button span is used to style the file input field as button -->
@@ -121,7 +121,7 @@
     </div>
     <!-- The table listing the files available for upload/download -->
     <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-</form><!-- The blueimp Gallery widget -->
+</div><!-- The blueimp Gallery widget -->
 <div id="blueimp-gallery" class="blueimp-gallery blueimp-gallery-controls" data-filter=":even">
     <div class="slides"></div>
     <h3 class="title"></h3>
@@ -207,7 +207,7 @@
 
 </script>
     <!-- The file upload form used as target for the file upload widget -->
-<form id="w2-form" action="http://example.com/upload.php" method="post" enctype="multipart/form-data" uploadTemplateId="#template-upload" downloadTemplateId="#template-download">    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+<div id="w2-fileupload" data-upload-template-id="template-upload" data-download-template-id="template-download">    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
     <div class="row fileupload-buttonbar">
         <div class="col-lg-7">
             <!-- The fileinput-button span is used to style the file input field as button -->
@@ -245,7 +245,7 @@
     </div>
     <!-- The table listing the files available for upload/download -->
     <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-</form><!-- The blueimp Gallery widget -->
+</div><!-- The blueimp Gallery widget -->
 <div id="blueimp-gallery" class="blueimp-gallery blueimp-gallery-controls" data-filter=":even">
     <div class="slides"></div>
     <h3 class="title"></h3>
@@ -331,7 +331,7 @@
 
 </script>
     <!-- The file upload form used as target for the file upload widget -->
-<form id="custom-id-form" action="http://example.com/upload.php" method="post" enctype="multipart/form-data" uploadTemplateId="#template-upload" downloadTemplateId="#template-download">    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+<div id="custom-id-fileupload" data-upload-template-id="template-upload" data-download-template-id="template-download">    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
     <div class="row fileupload-buttonbar">
         <div class="col-lg-7">
             <!-- The fileinput-button span is used to style the file input field as button -->
@@ -369,7 +369,7 @@
     </div>
     <!-- The table listing the files available for upload/download -->
     <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
-</form><!-- The blueimp Gallery widget -->
+</div><!-- The blueimp Gallery widget -->
 <div id="blueimp-gallery" class="blueimp-gallery blueimp-gallery-controls" data-filter=":even">
     <div class="slides"></div>
     <h3 class="title"></h3>
@@ -394,9 +394,9 @@
 <script src="/0/js/jquery.fileupload-validate.js"></script>
 <script src="/0/js/jquery.fileupload-ui.js"></script>
 <script type="text/javascript">jQuery(document).ready(function () {
-;jQuery('#model-test-form').fileupload({"url":"http://example.com/upload.php"});
-;jQuery('#w2-form').fileupload({"url":"http://example.com/upload.php"});
-;jQuery('#custom-id-form').fileupload({"url":"http://example.com/upload.php"});
-jQuery('#custom-id-form').on('test2', function () { });
+;jQuery('#model-test-fileupload').fileupload({"url":"http://example.com/upload.php"});
+;jQuery('#w2-fileupload').fileupload({"url":"http://example.com/upload.php"});
+;jQuery('#custom-id-fileupload').fileupload({"url":"http://example.com/upload.php"});
+jQuery('#custom-id-fileupload').on('test2', function () { });
 });</script></body>
 </html>

--- a/tests/data/test-file-upload-ui.bin
+++ b/tests/data/test-file-upload-ui.bin
@@ -93,18 +93,18 @@
 
                 <input type="hidden" name="Model[test]" value=""><input type="file" id="model-test" name="Model[test]" multiple>
             </span>
-            <button type="submit" class="btn btn-primary start">
+            <a class="btn btn-primary start">
                 <i class="glyphicon glyphicon-upload"></i>
                 <span>Start upload</span>
-            </button>
-            <button type="reset" class="btn btn-warning cancel">
+            </a>
+            <a class="btn btn-warning cancel">
                 <i class="glyphicon glyphicon-ban-circle"></i>
                 <span>Cancel upload</span>
-            </button>
-            <button type="button" class="btn btn-danger delete">
+            </a>
+            <a class="btn btn-danger delete">
                 <i class="glyphicon glyphicon-trash"></i>
                 <span>Delete</span>
-            </button>
+            </a>
             <input type="checkbox" class="toggle">
             <!-- The global file processing state -->
             <span class="fileupload-process"></span>
@@ -217,18 +217,18 @@
 
                 <input type="file" id="w2" name="test" multiple>
             </span>
-            <button type="submit" class="btn btn-primary start">
+            <a class="btn btn-primary start">
                 <i class="glyphicon glyphicon-upload"></i>
                 <span>Start upload</span>
-            </button>
-            <button type="reset" class="btn btn-warning cancel">
+            </a>
+            <a class="btn btn-warning cancel">
                 <i class="glyphicon glyphicon-ban-circle"></i>
                 <span>Cancel upload</span>
-            </button>
-            <button type="button" class="btn btn-danger delete">
+            </a>
+            <a class="btn btn-danger delete">
                 <i class="glyphicon glyphicon-trash"></i>
                 <span>Delete</span>
-            </button>
+            </a>
             <input type="checkbox" class="toggle">
             <!-- The global file processing state -->
             <span class="fileupload-process"></span>
@@ -341,18 +341,18 @@
 
                 <input type="file" id="custom-id" name="test" multiple>
             </span>
-            <button type="submit" class="btn btn-primary start">
+            <a class="btn btn-primary start">
                 <i class="glyphicon glyphicon-upload"></i>
                 <span>Start upload</span>
-            </button>
-            <button type="reset" class="btn btn-warning cancel">
+            </a>
+            <a class="btn btn-warning cancel">
                 <i class="glyphicon glyphicon-ban-circle"></i>
                 <span>Cancel upload</span>
-            </button>
-            <button type="button" class="btn btn-danger delete">
+            </a>
+            <a class="btn btn-danger delete">
                 <i class="glyphicon glyphicon-trash"></i>
                 <span>Delete</span>
-            </button>
+            </a>
             <input type="checkbox" class="toggle">
             <!-- The global file processing state -->
             <span class="fileupload-process"></span>


### PR DESCRIPTION
i fix template configuration ([like in docs](https://github.com/blueimp/jQuery-File-Upload/wiki/Multiple-File-Upload-Widgets-on-the-same-page#individual-uploaddownload-templates))

and change form to the div in plus ui example, and change buttons to a
it works the same, but you can use it in other forms