### PR TITLE
Load previously uploaded images

### DIFF
--- a/src/FileUploadUI.php
+++ b/src/FileUploadUI.php
@@ -26,6 +26,10 @@ class FileUploadUI extends BaseUpload
      */
     public $gallery = true;
     /**
+     * @var bool load previously uploaded images or not
+     */
+    public $load = false;
+    /**
      * @var array the HTML attributes for the file input tag.
      * @see \yii\helpers\Html::renderTagAttributes() for details on how attributes are being rendered.
      */
@@ -110,5 +114,20 @@ class FileUploadUI extends BaseUpload
             }
         }
         $view->registerJs(implode("\n", $js));
+
+        if ($this->load) {
+            $view->registerJs("
+                $('#$id').addClass('fileupload-processing');
+                $.ajax({
+                    url: $('#$id').fileupload('option', 'url'),
+                    dataType: 'json',
+                    context: $('#$id')[0]
+                }).always(function () {
+                    $(this).removeClass('fileupload-processing');
+                }).done(function (result) {
+                    $(this).fileupload('option', 'done').call(this, $.Event('done'), {result: result});
+                });
+            ");
+        }
     }
 }


### PR DESCRIPTION
Add property `load` in class `dosamigos\fileupload\FileUploadUI` which allow load existing images. This functionality has implemented in blueimp file upload extension for Yii 1 https://github.com/Asgaroth/xupload and in blueimp widget demo script https://github.com/blueimp/jQuery-File-Upload/blob/master/js/main.js#L59

I think this will solve  issue https://github.com/2amigos/yii2-file-upload-widget/issues/21