### PR TITLE
Correct FileUploadAction.php class name

### DIFF
--- a/src/actions/FileUploadAction.php
+++ b/src/actions/FileUploadAction.php
@@ -24,7 +24,7 @@ use yii\web\UploadedFile;
  * @author Antonio Ramirez <hola@2amigos.us>
  * @package dosamigos\fileupload\actions
  */
-class AbstractUploadAction extends Action
+class FileUploadAction extends Action
 {
     /**
      * @var string the AR class name that we need to link the uploaded instance to


### PR DESCRIPTION
Assuming there is not a reason for the class and file name to differ for this file I propose changing the class name AbstractUploadAction to match the file name FileUploadAction; which will also match the naming conventions of the other action files: FileListAction.php and FileDeleteAction.php.